### PR TITLE
I2C comm exception

### DIFF
--- a/axiom_tc/I2C_Comms.py
+++ b/axiom_tc/I2C_Comms.py
@@ -28,7 +28,7 @@ class I2C_Comms:
         try:
             self.__bus.i2c_rdwr(wr, rd)
         except IOError:
-            pass # Silently handle IOError. You see this when attempting to enter bootloader mode
+            pass # Silently handle IOError. Typically see this when in bootloader mode
 
         return list(rd)
 
@@ -47,7 +47,11 @@ class I2C_Comms:
         write = write_header + write_payload
 
         wr = i2c_msg.write(self.__addr, write)
-        self.__bus.i2c_rdwr(wr)
+
+        try:
+            self.__bus.i2c_rdwr(wr)
+        except IOError:
+            pass # Silently handle IOError. Typically see this when in bootloader mode
 
     def close(self):
         self.__bus.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axiom_tc"
-version = "4.8.7.0"
+version = "4.8.7.1"
 description = "Python library for TouchNetix aXiom Touch Controllers"
 license = { text = "MIT" }
 readme = "README.md"


### PR DESCRIPTION
Sometimes when the device is in the bootloader, an exception will occur during I2C comms when requesting the device to reset.

Up rev to v4.8.7.1.