### PR TITLE
Handle axiom in bootloader mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /axiom_tc.egg-info
 __pycache__
+/.idea

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ This library provides users the building blocks to communicate with the aXiom to
 
 `axiom.py` - Provides the main business logic and interface to aXiom.
 
+`Bootloader.py` - Manages the logic for handling firmware updates.
+
 `I2C_Comms.py` - Provides the logic for performing I2C comms to aXiom.
 
 `SPI_Comms.py` - Provides the logic for performing SPI comms to aXiom.
 
 `USB_Comms.py` - Provides the logic for performing USB comms to aXiom.
 
-`CDU_Common.py` - Some usages are CDU (command driven usages). These usages some some additional logic to read/write their contents.
+`CDU_Common.py` - Some usages are CDU (command driven usages). These usages use additional logic to read/write their contents.
 
 `u02_SystemManager.py` - Provides access to aXiom's system manager. The aXiom device can be reset, jump to bootloader, save config changes to flash etc.
 
@@ -92,7 +94,7 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="2f04", MODE="06
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="2f08", MODE="0666"
 ```
 
-The changes will apply on the next bootup. To apply the changes immediately:
+The changes will apply on the next reboot. To apply the changes immediately:
 
 ```console
 sudo udevadm control --reload-rules

--- a/axiom_tc/Bootloader.py
+++ b/axiom_tc/Bootloader.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2024 TouchNetix
+#
+# This file is part of axiom_tc and is released under the MIT License:
+# See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
+
+from time import sleep
+
+
+class Bootloader:
+    # Bootloader protocol registers
+    BLP_FIFO_ADDRESS = 0x0102
+    BLP_REG_COMMAND = 0x0100
+    BLP_REG_STATUS = 0x0100
+
+    def __init__(self, axiom=None, comms=None):
+        self._axiom = axiom
+        self._comms = comms
+
+    def enter_bootloader_mode(self):
+        attempts = 5
+
+        # If the chip is already in bootloader mode, no need to continue
+        if self._axiom.is_in_bootloader_mode():
+            return True
+
+        # Depending on the sequence, the usage table may not be populated at
+        # this moment. The device is not in bootloader mode, so it should be
+        # safe to build the usage table. The usage table is required to send the
+        # appropriate system manager commands to aXiom to get it into bootloader
+        # mode
+        if not self._axiom.u31.usage_table_populated:
+            self._axiom.u31.build_usage_table()
+
+        # Attempt to enter bootloader mode
+        while (not self._axiom.is_in_bootloader_mode()) and (attempts > 0):
+            # Entering bootloader mode is "involved" to ensure it is a deliberate
+            # request. Three "enter bootloader" commands are required, the number
+            # on the end is the sequence number, that will send the appropriate
+            # "magic" number to aXiom. If all is well, aXiom will be in the
+            # bootloader a few moments after the last command.
+            self._axiom.u02.send_command(self._axiom.u02.CMD_ENTER_BOOTLOADER)
+
+            # Check if the device is in bootloader mode
+            if self._axiom.is_in_bootloader_mode():
+                # Bootloader flag is set, no need to continue.
+                return True
+
+            attempts -= 1
+
+        # Failed to enter bootloader mode
+        return False
+
+    def _get_busy_status(self):
+        status = self._comms.read_page(self.BLP_REG_STATUS, 4)
+        # Busy bit is bit 0 of byte 2
+        return (status[2] & 0x01) != 0
+
+    def _wait_until_not_busy(self):
+        current_timeout = 0
+        while self._get_busy_status():
+            # aXiom is busy, wait 1ms before trying again
+            if current_timeout < self._axiom.TIMEOUT_MS:
+                current_timeout = current_timeout + 1
+            else:
+                print("ERROR: aXiom does not seem to be responding...")
+                raise TimeoutError
+
+            # If busy, allow the bootloader to run a bit longer before asking again
+            sleep(0.001)
+
+    def reset_axiom(self):
+        self._comms.write_page(self.BLP_REG_COMMAND, 2, [0x02, 0x00])
+
+    def write_chunk(self, chunk):
+        # Ensure aXiom is available to process our request
+        self._wait_until_not_busy()
+
+        offset = 0
+        length = len(chunk)
+
+        # The following slicing depends on the type of communication link.
+        # here we probe the comms class to see if we have any USB specific
+        # constants declared. If this is not the case then we assume chunk
+        # size compatible with I2C/SPI.
+        try:
+            if self._comms.wMaxPacketSize > self._axiom.u31.PAGE_SIZE:
+                chunk_size = (self._axiom.u31.PAGE_SIZE - 1) - self._comms.AX_HEADER_LEN
+            else:
+                chunk_size = (self._comms.wMaxPacketSize - 1) \
+                             - self._comms.AX_TBP_I2C_DEV_HEAD_LEN \
+                             - self._comms.AX_HEADER_LEN
+        except AttributeError:
+            chunk_size = self._axiom.u31.PAGE_SIZE - 1
+
+        while offset < length:
+            # Calculate how much data to transfer, up to the max transfer size
+            if (offset + chunk_size) < length:
+                length_to_write = chunk_size
+            else:
+                length_to_write = length - offset
+
+            # Extract the data to be transferred
+            payload_chunk = chunk[offset:(offset + length_to_write)]
+
+            # Send the data to aXiom
+            self._comms.write_page(self.BLP_FIFO_ADDRESS, length_to_write, payload_chunk)
+
+            # Ensure aXiom is available to process our request
+            self._wait_until_not_busy()
+            offset += length_to_write

--- a/axiom_tc/CDU_Common.py
+++ b/axiom_tc/CDU_Common.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 from time import sleep
@@ -29,7 +29,6 @@ class CDU_Common:
 
     def __cdu_query(self, usage):
         cdu_buffer = [0x00] * self.__axiom.get_usage_length(usage)
-        cdu_usage_length = 0
 
         command = CDU_Common.CDU_CMD_QUERY
 

--- a/axiom_tc/I2C_Comms.py
+++ b/axiom_tc/I2C_Comms.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 from smbus2 import SMBus, i2c_msg
@@ -30,7 +30,7 @@ class I2C_Comms:
         try:
             self._bus.i2c_rdwr(wr, rd)
         except IOError:
-            pass # Silently handle IOError. Typically see this when in bootloader mode
+            pass  # Silently handle IOError. Typically, see this when in bootloader mode
 
         return list(rd)
 
@@ -47,11 +47,11 @@ class I2C_Comms:
         write_payload = payload
         write = write_header + write_payload
 
-        wr = i2c_msg.write(self.__addr, write)
+        wr = i2c_msg.write(self._addr, write)
         try:
-            self.__bus.i2c_rdwr(wr)
+            self._bus.i2c_rdwr(wr)
         except IOError:
-            pass # Silently handle IOError. Typically see this when in bootloader mode
+            pass  # Silently handle IOError. Typically, see this when in bootloader mode
 
     def close(self):
         self._bus.close()

--- a/axiom_tc/SPI_Comms.py
+++ b/axiom_tc/SPI_Comms.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 import spidev

--- a/axiom_tc/USB_Comms.py
+++ b/axiom_tc/USB_Comms.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 import hid
@@ -315,7 +315,7 @@ class USB_Comms:
         buffer = list(self.EMPTY_PKT)
         buffer[1] = self.AX_CMD_RESET
         self.__device.write(bytes(buffer[0:self.hidPayloadSize]))
-        # There is no response, the bridge will soft reset and re-enumerate on the USB bus...
+        # There is no response, the bridge will be soft reset and re-enumerate on the USB bus
 
     def send_null(self):
         buffer_wr = list(self.EMPTY_PKT)

--- a/axiom_tc/__init__.py
+++ b/axiom_tc/__init__.py
@@ -15,6 +15,7 @@ from .u48_GPIOControls import *
 
 __all__ = [
     "axiom",
+    "Bootloader",
     "CDU_Common",
     "u02_SystemManager",
     "u06_SelfTest",
@@ -22,8 +23,19 @@ __all__ = [
     "u31_DeviceInformation",
     "u32_DeviceCapabilities",
     "u33_CRCData",
-    "u48_GPIOControls"
+    "u48_GPIOControls",
 ]
+
+from .axiom import axiom
+from .Bootloader import Bootloader
+from .CDU_Common import CDU_Common
+from .u02_SystemManager import u02_SystemManager
+from .u06_SelfTest import u06_SelfTest
+from .u07_LiveView import u07_LiveView
+from .u31_DeviceInformation import u31_DeviceInformation
+from .u32_DeviceCapabilities import u32_DeviceCapabilities
+from .u33_CRCData import u33_CRCData
+from .u48_GPIOControls import u48_GPIOControls
 
 try:
     from .USB_Comms import *

--- a/axiom_tc/__init__.py
+++ b/axiom_tc/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 from .axiom import *

--- a/axiom_tc/u02_SystemManager.py
+++ b/axiom_tc/u02_SystemManager.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 import struct

--- a/axiom_tc/u06_SelfTest.py
+++ b/axiom_tc/u06_SelfTest.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 import struct

--- a/axiom_tc/u07_LiveView.py
+++ b/axiom_tc/u07_LiveView.py
@@ -1,9 +1,79 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 import struct
+
+
+def convert_u83_measurement_noise_to_string(noise_as_float100):
+    return "%.2f" % (float(noise_as_float100) / 100)
+
+
+def convert_u83_channel_state_to_string(state):
+    if state == 0:
+        return "Scan"
+    elif state == 1:
+        return "Capture"
+    elif state == 2:
+        return "Settle"
+    elif state == 3:
+        return "Qualification"
+    elif state == 4:
+        return "Ready"
+    elif state == 5:
+        return "Noisy"
+    elif state == 6:
+        return "Inactive"
+    elif state == 7:
+        return "Reset"
+    else:
+        return "<UNKNOWN_U83_CHANNEL_STATE>"
+
+
+def convert_self_test_result_to_string(result):
+    if result == 0x00:
+        return "Not Yet Run"
+    elif result == 0x01:
+        return "In Progress"
+    elif result == 0x02:
+        return "Pass"
+    elif result == 0x03:
+        return "Must Retry"
+    elif result == 0x7E:
+        return "Not Implemented"
+    elif result == 0x7F:
+        return "Never Run"
+    elif (result & 0x80) != 0:
+        return "Fail (Extended Error Bits: 0x%02X)" % (result & 0x7F)
+    else:
+        return "<UNKNOWN_SELF_TEST_RESULT>"
+
+
+def convert_self_test_overall_result_to_string(overall_result):
+    if overall_result == 0x01:
+        return "In Progress"
+    elif overall_result == 0x02:
+        return "Pass"
+    elif overall_result == 0x7D:
+        return "No Tests Done"
+    elif overall_result == 0x7F:
+        return "Never Run"
+    elif overall_result == 0x80:
+        return "Fail"
+    else:
+        return "<UNKNOWN_OVERALL_RESULT>"
+
+
+def convert_self_test_cause_to_string(cause):
+    if cause == 0:
+        return "Boot"
+    elif cause == 1:
+        return "Heartbeat"
+    elif cause == 2:
+        return "Host Triggered"
+    else:
+        return "<UNKNOWN_CAUSE>"
 
 
 class u07_LiveView:
@@ -57,70 +127,6 @@ class u07_LiveView:
         self._unpack_registers()
 
     # region Value to String Conversions
-    def convert_self_test_cause_to_string(self, cause):
-        if cause == 0:
-            return "Boot"
-        elif cause == 1:
-            return "Heartbeat"
-        elif cause == 2:
-            return "Host Triggered"
-        else:
-            return "<UNKNOWN_CAUSE>"
-
-    def convert_self_test_overall_result_to_string(self, overall_result):
-        if overall_result == 0x01:
-            return "In Progress"
-        elif overall_result == 0x02:
-            return "Pass"
-        elif overall_result == 0x7D:
-            return "No Tests Done"
-        elif overall_result == 0x7F:
-            return "Never Run"
-        elif overall_result == 0x80:
-            return "Fail"
-        else:
-            return "<UNKNOWN_OVERALL_RESULT>"
-
-    def convert_self_test_result_to_string(self, result):
-        if result == 0x00:
-            return "Not Yet Run"
-        elif result == 0x01:
-            return "In Progress"
-        elif result == 0x02:
-            return "Pass"
-        elif result == 0x03:
-            return "Must Retry"
-        elif result == 0x7E:
-            return "Not Implemented"
-        elif result == 0x7F:
-            return "Never Run"
-        elif (result & 0x80) != 0:
-            return "Fail (Extended Error Bits: 0x%02X)" % (result & 0x7F)
-        else:
-            return "<UNKNOWN_SELF_TEST_RESULT>"
-
-    def convert_u83_channel_state_to_string(self, state):
-        if state == 0:
-            return "Scan"
-        elif state == 1:
-            return "Capture"
-        elif state == 2:
-            return "Settle"
-        elif state == 3:
-            return "Qualification"
-        elif state == 4:
-            return "Ready"
-        elif state == 5:
-            return "Noisy"
-        elif state == 6:
-            return "Inactive"
-        elif state == 7:
-            return "Reset"
-        else:
-            return "<UNKNOWN_U83_CHANNEL_STATE>"
-
-    def convert_u83_measurement_noise_to_string(self, noise_as_float100):
-        return "%.2f" % (float(noise_as_float100) / 100)
 
     # endregion
 
@@ -328,47 +334,47 @@ class u07_LiveView:
         print("")
         print("  Drifting Indicators")
         print("  Trans Drifting : %s" % ("Drifting" if self.reg_trans_drifting_active == 1 else "Not Drifting"))
-        print("  Abs Drifiting  : %s" % ("Drifting" if self.reg_abs_drifting_active == 1 else "Not Drifting"))
+        print("  Abs Drifting   : %s" % ("Drifting" if self.reg_abs_drifting_active == 1 else "Not Drifting"))
         print("  Aux Drifting   : %s" % ("Drifting" if self.reg_aux_drifting_active == 1 else "Not Drifting"))
         print("")
         print("  Self Test Status")
         print(
             "    u06 Self Test Status               : %s" % ("Idle" if self.reg_u06_self_test_status == 0 else "Busy"))
-        print("    u06 Self Test Triggered By         : %s" % self.convert_self_test_cause_to_string(
+        print("    u06 Self Test Triggered By         : %s" % convert_self_test_cause_to_string(
             self.reg_u06_self_test_cause))
         print("    u06 Self Test Current Test Running : %u" % self.reg_u06_self_test_number)
-        print("    u06 Self Test Overall Result       : %s" % self.convert_self_test_overall_result_to_string(
+        print("    u06 Self Test Overall Result       : %s" % convert_self_test_overall_result_to_string(
             self.reg_u06_self_test_overall_result))
         print("    u06 Self Test Debug Data           : %u" % self.reg_u06_self_test_general_debug)
         print("")
         print("  Self Test Results")
-        print("    Test  0 CPU RAM Test                      : %s" % self.convert_self_test_result_to_string(
+        print("    Test  0 CPU RAM Test                      : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[0]))
-        print("    Test  1 AE Baseline RAM Test              : %s" % self.convert_self_test_result_to_string(
+        print("    Test  1 AE Baseline RAM Test              : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[1]))
-        print("    Test  2 AE Internal RAM Test              : %s" % self.convert_self_test_result_to_string(
+        print("    Test  2 AE Internal RAM Test              : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[2]))
-        print("    Test  3 VDDA Test                         : %s" % self.convert_self_test_result_to_string(
+        print("    Test  3 VDDA Test                         : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[3]))
-        print("    Test  4 AE Test                           : %s" % self.convert_self_test_result_to_string(
+        print("    Test  4 AE Test                           : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[4]))
-        print("    Test  5 Sense and Shield Pin Leakage Test : %s" % self.convert_self_test_result_to_string(
+        print("    Test  5 Sense and Shield Pin Leakage Test : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[5]))
-        print("    Test  6 Trans Cap Signal Limits Test      : %s" % self.convert_self_test_result_to_string(
+        print("    Test  6 Trans Cap Signal Limits Test      : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[6]))
-        print("    Test  7 Abs Cap Signal Limits Test        : %s" % self.convert_self_test_result_to_string(
+        print("    Test  7 Abs Cap Signal Limits Test        : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[7]))
-        print("    Test  8 AUX Signal Limits Test            : %s" % self.convert_self_test_result_to_string(
+        print("    Test  8 AUX Signal Limits Test            : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[8]))
-        print("    Test  9 CRC Generate and Check Test       : %s" % self.convert_self_test_result_to_string(
+        print("    Test  9 CRC Generate and Check Test       : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[9]))
-        print("    Test 10 nIRQ Pin Test                     : %s" % self.convert_self_test_result_to_string(
+        print("    Test 10 nIRQ Pin Test                     : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[10]))
-        print("    Test 11 NVM Test                          : %s" % self.convert_self_test_result_to_string(
+        print("    Test 11 NVM Test                          : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[11]))
-        print("    Test 12 RTC Test                          : %s" % self.convert_self_test_result_to_string(
+        print("    Test 12 RTC Test                          : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[12]))
-        print("    Test 13 VDDC Test                         : %s" % self.convert_self_test_result_to_string(
+        print("    Test 13 VDDC Test                         : %s" % convert_self_test_result_to_string(
             self.reg_u06_self_test_results[13]))
         print("")
         print("GPIOs State")
@@ -415,32 +421,32 @@ class u07_LiveView:
         print("  u83 Channel Status")
         print("                  %13s %13s %13s" % ("0".center(13), "1".center(13), "2".center(13)))
         print("    Trans State : %13s %13s %13s" % (
-            self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[0]),
-            self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[1]),
-            self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[2])))
+            convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[0]),
+            convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[1]),
+            convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[2])))
         print("    Abs State   : %13s %13s %13s" % (
-            self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[0]),
-            self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[1]),
-            self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[2])))
+            convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[0]),
+            convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[1]),
+            convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[2])))
         print("    Aux State   : %13s %13s %13s" % (
-            self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[0]),
-            self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[1]),
-            self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[2])))
+            convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[0]),
+            convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[1]),
+            convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[2])))
         print("    Active OP   : %13u %13u %13u" % (
             self.reg_u83_channel_status_operating_point[0], self.reg_u83_channel_status_operating_point[1],
             self.reg_u83_channel_status_operating_point[2]))
         print("    Trans Noise : %12s%% %12s%% %12s%%" % (
-            self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[0]),
-            self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[1]),
-            self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[2])))
+            convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[0]),
+            convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[1]),
+            convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[2])))
         print("    Abs Noise   : %12s%% %12s%% %12s%%" % (
-            self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[0]),
-            self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[1]),
-            self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[2])))
+            convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[0]),
+            convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[1]),
+            convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[2])))
         print("    Aux Noise   : %12s%% %12s%% %12s%%" % (
-            self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[0]),
-            self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[1]),
-            self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[2])))
+            convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[0]),
+            convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[1]),
+            convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[2])))
 
     # endregion
 
@@ -587,37 +593,37 @@ def _print_registers_uifrev8(self):
     print("  Self Test Status")
     print(
         "    u06 Self Test Status               : %s" % ("Idle" if self.reg_u06_self_test_status == 0 else "Busy"))
-    print("    u06 Self Test Triggered By         : %s" % self.convert_self_test_cause_to_string(
+    print("    u06 Self Test Triggered By         : %s" % convert_self_test_cause_to_string(
         self.reg_u06_self_test_cause))
     print("    u06 Self Test Current Test Running : %u" % self.reg_u06_self_test_number)
-    print("    u06 Self Test Overall Result       : %s" % self.convert_self_test_overall_result_to_string(
+    print("    u06 Self Test Overall Result       : %s" % convert_self_test_overall_result_to_string(
         self.reg_u06_self_test_overall_result))
     print("    u06 Self Test Debug Data           : %u" % self.reg_u06_self_test_general_debug)
     print("")
     print("  Self Test Results")
-    print("    Test  0 CPU RAM Test                      : %s" % self.convert_self_test_result_to_string(
+    print("    Test  0 CPU RAM Test                      : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[0]))
-    print("    Test  1 AE Baseline RAM Test              : %s" % self.convert_self_test_result_to_string(
+    print("    Test  1 AE Baseline RAM Test              : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[1]))
-    print("    Test  2 AE Internal RAM Test              : %s" % self.convert_self_test_result_to_string(
+    print("    Test  2 AE Internal RAM Test              : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[2]))
-    print("    Test  3 VDDA Test                         : %s" % self.convert_self_test_result_to_string(
+    print("    Test  3 VDDA Test                         : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[3]))
-    print("    Test  4 AE Test                           : %s" % self.convert_self_test_result_to_string(
+    print("    Test  4 AE Test                           : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[4]))
-    print("    Test  5 Sense and Shield Pin Leakage Test : %s" % self.convert_self_test_result_to_string(
+    print("    Test  5 Sense and Shield Pin Leakage Test : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[5]))
-    print("    Test  8 AUX Signal Limits Test            : %s" % self.convert_self_test_result_to_string(
+    print("    Test  8 AUX Signal Limits Test            : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[8]))
-    print("    Test  9 CRC Generate and Check Test       : %s" % self.convert_self_test_result_to_string(
+    print("    Test  9 CRC Generate and Check Test       : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[9]))
-    print("    Test 10 nIRQ Pin Test                     : %s" % self.convert_self_test_result_to_string(
+    print("    Test 10 nIRQ Pin Test                     : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[10]))
-    print("    Test 11 NVM Test                          : %s" % self.convert_self_test_result_to_string(
+    print("    Test 11 NVM Test                          : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[11]))
-    print("    Test 12 RTC Test                          : %s" % self.convert_self_test_result_to_string(
+    print("    Test 12 RTC Test                          : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[12]))
-    print("    Test 13 VDDC Test                         : %s" % self.convert_self_test_result_to_string(
+    print("    Test 13 VDDC Test                         : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[13]))
     print("")
     print("GPIOs State")
@@ -636,26 +642,26 @@ def _print_registers_uifrev8(self):
     print("  u83 Channel Status")
     print("                  %13s %13s %13s" % ("0".center(13), "1".center(13), "2".center(13)))
     print("    Aux State   : %13s %13s %13s" % (
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[0]),
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[1]),
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[2])))
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[0]),
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[1]),
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[2])))
     print("    Active OP   : %13u %13u %13u" % (
         self.reg_u83_channel_status_operating_point[0], self.reg_u83_channel_status_operating_point[1],
         self.reg_u83_channel_status_operating_point[2]))
     print("    Aux Noise   : %12s%% %12s%% %12s%%" % (
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[0]),
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[1]),
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[2])))
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[0]),
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[1]),
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[2])))
     print("  u83 Channel Status")
     print("                  %13s %13s %13s" % ("0".center(13), "1".center(13), "2".center(13)))
     print("     AutoTune Error : %13s %13s %13s" % (
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[0]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[1]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[2])))
+        convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[0]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[1]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[2])))
     print("     Aux Operating Point Errors : %13s %13s %13s" % (
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[0]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[1]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[2])))
+        convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[0]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[1]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[2])))
 
 
 # endregion
@@ -892,47 +898,47 @@ def _print_registers_uifrev9(self):
     print("")
     print("  Drifting Indicators")
     print("  Trans Drifting : %s" % ("Drifting" if self.reg_trans_drifting_active == 1 else "Not Drifting"))
-    print("  Abs Drifiting  : %s" % ("Drifting" if self.reg_abs_drifting_active == 1 else "Not Drifting"))
+    print("  Abs Drifting   : %s" % ("Drifting" if self.reg_abs_drifting_active == 1 else "Not Drifting"))
     print("  Aux Drifting   : %s" % ("Drifting" if self.reg_aux_drifting_active == 1 else "Not Drifting"))
     print("")
     print("  Self Test Status")
     print(
         "    u06 Self Test Status               : %s" % ("Idle" if self.reg_u06_self_test_status == 0 else "Busy"))
-    print("    u06 Self Test Triggered By         : %s" % self.convert_self_test_cause_to_string(
+    print("    u06 Self Test Triggered By         : %s" % convert_self_test_cause_to_string(
         self.reg_u06_self_test_cause))
     print("    u06 Self Test Current Test Running : %u" % self.reg_u06_self_test_number)
-    print("    u06 Self Test Overall Result       : %s" % self.convert_self_test_overall_result_to_string(
+    print("    u06 Self Test Overall Result       : %s" % convert_self_test_overall_result_to_string(
         self.reg_u06_self_test_overall_result))
     print("    u06 Self Test Debug Data           : %u" % self.reg_u06_self_test_general_debug)
     print("")
     print("  Self Test Results")
-    print("    Test  0 CPU RAM Test                      : %s" % self.convert_self_test_result_to_string(
+    print("    Test  0 CPU RAM Test                      : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[0]))
-    print("    Test  1 AE Baseline RAM Test              : %s" % self.convert_self_test_result_to_string(
+    print("    Test  1 AE Baseline RAM Test              : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[1]))
-    print("    Test  2 AE Internal RAM Test              : %s" % self.convert_self_test_result_to_string(
+    print("    Test  2 AE Internal RAM Test              : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[2]))
-    print("    Test  3 VDDA Test                         : %s" % self.convert_self_test_result_to_string(
+    print("    Test  3 VDDA Test                         : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[3]))
-    print("    Test  4 AE Test                           : %s" % self.convert_self_test_result_to_string(
+    print("    Test  4 AE Test                           : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[4]))
-    print("    Test  5 Sense and Shield Pin Leakage Test : %s" % self.convert_self_test_result_to_string(
+    print("    Test  5 Sense and Shield Pin Leakage Test : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[5]))
-    print("    Test  6 Trans Cap Signal Limits Test      : %s" % self.convert_self_test_result_to_string(
+    print("    Test  6 Trans Cap Signal Limits Test      : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[6]))
-    print("    Test  7 Abs Cap Signal Limits Test        : %s" % self.convert_self_test_result_to_string(
+    print("    Test  7 Abs Cap Signal Limits Test        : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[7]))
-    print("    Test  8 AUX Signal Limits Test            : %s" % self.convert_self_test_result_to_string(
+    print("    Test  8 AUX Signal Limits Test            : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[8]))
-    print("    Test  9 CRC Generate and Check Test       : %s" % self.convert_self_test_result_to_string(
+    print("    Test  9 CRC Generate and Check Test       : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[9]))
-    print("    Test 10 nIRQ Pin Test                     : %s" % self.convert_self_test_result_to_string(
+    print("    Test 10 nIRQ Pin Test                     : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[10]))
-    print("    Test 11 NVM Test                          : %s" % self.convert_self_test_result_to_string(
+    print("    Test 11 NVM Test                          : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[11]))
-    print("    Test 12 RTC Test                          : %s" % self.convert_self_test_result_to_string(
+    print("    Test 12 RTC Test                          : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[12]))
-    print("    Test 13 VDDC Test                         : %s" % self.convert_self_test_result_to_string(
+    print("    Test 13 VDDC Test                         : %s" % convert_self_test_result_to_string(
         self.reg_u06_self_test_results[13]))
     print("")
     print("GPIOs State")
@@ -979,54 +985,54 @@ def _print_registers_uifrev9(self):
     print("  u83 Channel Status")
     print("                  %13s %13s %13s" % ("0".center(13), "1".center(13), "2".center(13)))
     print("    Trans State : %13s %13s %13s" % (
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[0]),
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[1]),
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[2])))
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[0]),
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[1]),
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_trans_state[2])))
     print("    Abs State   : %13s %13s %13s" % (
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[0]),
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[1]),
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[2])))
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[0]),
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[1]),
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_abs_state[2])))
     print("    Aux State   : %13s %13s %13s" % (
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[0]),
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[1]),
-        self.convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[2])))
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[0]),
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[1]),
+        convert_u83_channel_state_to_string(self.reg_u83_channel_status_aux_state[2])))
     print("    Active OP   : %13u %13u %13u" % (
         self.reg_u83_channel_status_operating_point[0], self.reg_u83_channel_status_operating_point[1],
         self.reg_u83_channel_status_operating_point[2]))
     print("    Trans Noise : %12s%% %12s%% %12s%%" % (
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[0]),
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[1]),
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[2])))
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[0]),
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[1]),
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_trans_noise[2])))
     print("    Abs Noise   : %12s%% %12s%% %12s%%" % (
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[0]),
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[1]),
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[2])))
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[0]),
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[1]),
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_abs_noise[2])))
     print("    Aux Noise   : %12s%% %12s%% %12s%%" % (
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[0]),
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[1]),
-        self.convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[2])))
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[0]),
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[1]),
+        convert_u83_measurement_noise_to_string(self.reg_u83_channel_status_aux_noise[2])))
     print("  u83 Channel Status")
     print("                  %13s %13s %13s" % ("0".center(13), "1".center(13), "2".center(13)))
     print("     AutoTune Error : %13s %13s %13s" % (
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[0]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[1]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[2])))
+        convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[0]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[1]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_error_code[2])))
     print("     Trans Operating Point Errors : %13s %13s %13s" % (
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_trans_operating_point[0]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_trans_operating_point[1]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_trans_operating_point[2])))
+        convert_self_test_result_to_string(self.reg_u83_channel_status_trans_operating_point[0]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_trans_operating_point[1]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_trans_operating_point[2])))
     print("     Abs Cols Operating Point Errors : %13s %13s %13s" % (
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_abs_cols_operating_point[0]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_abs_cols_operating_point[1]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_abs_cols_operating_point[2])))
+        convert_self_test_result_to_string(self.reg_u83_channel_status_abs_cols_operating_point[0]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_abs_cols_operating_point[1]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_abs_cols_operating_point[2])))
     print("     Abs Rows Operating Point Errors : %13s %13s %13s" % (
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_abs_rows_operating_point[0]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_abs_rows_operating_point[1]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_abs_rows_operating_point[2])))
+        convert_self_test_result_to_string(self.reg_u83_channel_status_abs_rows_operating_point[0]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_abs_rows_operating_point[1]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_abs_rows_operating_point[2])))
     print("     Aux Operating Point Errors : %13s %13s %13s" % (
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[0]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[1]),
-        self.convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[2])))
+        convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[0]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[1]),
+        convert_self_test_result_to_string(self.reg_u83_channel_status_aux_operating_point[2])))
 
 
 # endregion

--- a/axiom_tc/u31_DeviceInformation.py
+++ b/axiom_tc/u31_DeviceInformation.py
@@ -98,10 +98,14 @@ class u31_DeviceInformation:
                                                                   fw_variant))
 
     def convert_firmware_version_to_string(self, major, minor, patch, status, fw_variant):
-        if major >= 4 and minor >= 8:
-            return "%d.%d.%d-%s %s" % (major, minor, patch, self.FW_STATUS[status], self.FW_VARIANTS[fw_variant])
+        if self.reg_mode == 0:
+            if major >= 4 and minor >= 8:
+                return "%d.%d.%d-%s %s" % (major, minor, patch, self.FW_STATUS[status], self.FW_VARIANTS[fw_variant])
+            else:
+                return "%d.%02d-%s (RC%d) %s" % (
+                    major, minor, self.FW_STATUS[status], patch, self.FW_VARIANTS[fw_variant])
         else:
-            return "%d.%02d-%s (RC%d) %s" % (major, minor, self.FW_STATUS[status], patch, self.FW_VARIANTS[fw_variant])
+            return "Bootloader %d.%02d" % (major, minor)
 
     def _unpack(self):
         self._unpack_registers()
@@ -116,7 +120,6 @@ class u31_DeviceInformation:
 
         # Verify the device is not in bootloader mode
         if self.reg_mode != 0:
-            print("Cannot build usage table, aXiom is in bootloader mode")
             return False
 
         target_address = self.convert_usage_to_target_address(0x31, 1)
@@ -160,7 +163,7 @@ class u31_DeviceInformation:
             print("Usage table not yet initialised")
 
     def convert_usage_to_target_address(self, usage, page=0):
-        if self._usage_table_populated is False and usage == 0x31:
+        if self._usage_table_populated is False or usage == 0x31:
             target_address = 0x0000 + (page << 8)
         else:
             target_address = (self._usage_table[usage].start_page << 8) + (page << 8)

--- a/axiom_tc/u31_DeviceInformation.py
+++ b/axiom_tc/u31_DeviceInformation.py
@@ -25,12 +25,6 @@ class _Usage_Table_Entry:
                            "Report" if self.is_report else "")
 
 
-def convert_device_id_to_string(device_id):
-    device_channel_count = device_id & 0x3FF
-    device_variant = (device_id & 0x7C00) >> 10
-    return "AX%u%c" % (device_channel_count, chr(ord('A') + device_variant))
-
-
 class u31_DeviceInformation:
     USAGE_ID = 0x31
 
@@ -88,12 +82,17 @@ class u31_DeviceInformation:
     def print_device_info(self):
         self._print_registers()
 
+    def convert_device_id_to_string(self, device_id):
+        device_channel_count = device_id & 0x3FF
+        device_variant = (device_id & 0x7C00) >> 10
+        return "AX%u%c" % (device_channel_count, chr(ord('A') + device_variant))
+
     def get_device_info_short(self):
         return self.convert_device_info_to_string(self.reg_device_id, self.reg_fw_variant, self.reg_fw_major,
                                                   self.reg_fw_minor, self.reg_fw_patch, self.reg_fw_status)
 
     def convert_device_info_to_string(self, device_id, fw_variant, fw_ver_major, fw_ver_minor, fw_ver_patch, fw_status):
-        return "%s %s" % (convert_device_id_to_string(device_id),
+        return "%s %s" % (self.convert_device_id_to_string(device_id),
                           self.convert_firmware_version_to_string(fw_ver_major, fw_ver_minor, fw_ver_patch, fw_status,
                                                                   fw_variant))
 

--- a/axiom_tc/u32_DeviceCapabilities.py
+++ b/axiom_tc/u32_DeviceCapabilities.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 import struct
-from time import sleep
 
 
 class u32_DeviceCapabilities:
@@ -47,8 +46,7 @@ class u32_DeviceCapabilities:
         self._usage_binary_data = self._axiom.read_usage(self.USAGE_ID)
         self._unpack()
 
-    def write(self, write_to_nvm=False):
-        self.read()
+    def write(self):
         raise Exception("Cannot write to u33. u33 is a read-only usage.")
 
     def print(self):
@@ -96,7 +94,7 @@ class u32_DeviceCapabilities:
             num_cts_driven_traces, num_aux_driven_traces, num_a_channels, num_b_channels, \
             num_c_channels, num_d_channels, num_e_channels, num_f_channels, max_map_lengthbytes, \
             max_baseline_length_bytes, num_baselines, _, interfaces, khz_to_jump_thousands = struct.unpack(
-            "<H10B2HBBHI", bytes(bytearray(self._usage_binary_data[0:24])))
+                "<H10B2H2BHI", bytes(bytearray(self._usage_binary_data[0:24])))
 
         self.reg_max_cts_nodes = max_cts_nodes
         self.reg_num_cts_channels = num_cts_channels

--- a/axiom_tc/u33_CRCData.py
+++ b/axiom_tc/u33_CRCData.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 import struct
-from time import sleep
 
 
 class u33_CRCData:
@@ -116,7 +115,7 @@ class u33_CRCData:
             if other_u33._usage_revision < 3:
                 # The "other" u33 doesn't contain u77, skip it and assume CRC is OK
                 if print_results:
-                    print("  u77 DoD Calibration Data CRC : 0x%08X - NOTPRESENT - SKIPPED" % (
+                    print("  u77 DoD Calibration Data CRC : 0x%08X - NOT PRESENT - SKIPPED" % (
                         self.reg_u77_dod_calibration_data_crc))
             else:
                 u77_ok = self.reg_u77_dod_calibration_data_crc == other_u33.reg_u77_dod_calibration_data_crc
@@ -138,7 +137,7 @@ class u33_CRCData:
 
         if do_u94_check:
             u94_ok = self.reg_u94_delta_scale_map_cdu_crc == other_u33.reg_u94_delta_scale_map_cdu_crc
-            if not u93_ok:
+            if not u94_ok:
                 overall_u33_ok = False
             if print_results:
                 print("  u94 Delta Scale Map CRC      : 0x%08X - 0x%08X - %s" % (
@@ -156,7 +155,7 @@ class u33_CRCData:
         self.reg_bootloader_crc = 0
         self.reg_nvltl_usage_config_crc = 0
         self.reg_vltl_usage_config_crc = 0
-        self.reg_u05_commenrs_crc = 0
+        self.reg_u05_comments_crc = 0
         self.reg_u22_sequence_data_cdu_crc = 0
         self.reg_u43_hotspots_cdu_crc = 0
         self.reg_u93_profiles_cdu_crc = 0
@@ -164,14 +163,15 @@ class u33_CRCData:
         self.reg_runtime_hash = 0
 
     def _unpack_uifrev1(self):
-        rt_crc, rt_nvm_crc, bl_crc, nvltl_config_crc, vltl_config_crc, u05_crc, u22_crc, u43_crc, u93_crc, u94_crc, hash = struct.unpack(
+        (rt_crc, rt_nvm_crc, bl_crc, nvltl_config_crc, vltl_config_crc, u05_crc, u22_crc, u43_crc, u93_crc, u94_crc,
+         hash) = struct.unpack(
             "<11I", bytes(bytearray(self._usage_binary_data[0:44])))
         self.reg_runtime_crc = rt_crc
         self.reg_runtime_nvm_crc = rt_nvm_crc
         self.reg_bootloader_crc = bl_crc
         self.reg_nvltl_usage_config_crc = nvltl_config_crc
         self.reg_vltl_usage_config_crc = vltl_config_crc
-        self.reg_u05_commenrs_crc = u05_crc
+        self.reg_u05_comments_crc = u05_crc
         self.reg_u22_sequence_data_cdu_crc = u22_crc
         self.reg_u43_hotspots_cdu_crc = u43_crc
         self.reg_u93_profiles_cdu_crc = u93_crc
@@ -187,7 +187,7 @@ class u33_CRCData:
         print("  RAM Usage Config CRC    : 0x{:08X}".format(self.reg_vltl_usage_config_crc))
 
         if self._axiom.u31.is_usage_present_on_device(0x05):
-            print("  u05 Comments CRC        : 0x{:08X}".format(self.reg_u05_commenrs_crc))
+            print("  u05 Comments CRC        : 0x{:08X}".format(self.reg_u05_comments_crc))
 
         if self._axiom.u31.is_usage_present_on_device(0x22):
             print("  u22 Sequence Data CRC   : 0x{:08X}".format(self.reg_u22_sequence_data_cdu_crc))
@@ -218,8 +218,8 @@ class u33_CRCData:
         self.reg_runtime_hash = 0
 
     def _unpack_uifrev2(self):
-        rt_crc, rt_nvm_crc, bl_crc, nvltl_config_crc, vltl_config_crc, u22_crc, u43_crc, u93_crc, u94_crc, hash = struct.unpack(
-            "<10I", bytes(bytearray(self._usage_binary_data[0:40])))
+        rt_crc, rt_nvm_crc, bl_crc, nvltl_config_crc, vltl_config_crc, u22_crc, u43_crc, u93_crc, u94_crc, hash = (
+            struct.unpack("<10I", bytes(bytearray(self._usage_binary_data[0:40]))))
         self.reg_runtime_crc = rt_crc
         self.reg_runtime_nvm_crc = rt_nvm_crc
         self.reg_bootloader_crc = bl_crc
@@ -269,7 +269,8 @@ class u33_CRCData:
         self.reg_runtime_hash = 0
 
     def _unpack_uifrev3(self):
-        rt_crc, rt_nvm_crc, bl_crc, nvltl_config_crc, vltl_config_crc, u22_crc, u43_crc, u77_crc, u93_crc, u94_crc, hash = struct.unpack(
+        (rt_crc, rt_nvm_crc, bl_crc, nvltl_config_crc, vltl_config_crc, u22_crc, u43_crc, u77_crc, u93_crc, u94_crc,
+         hash) = struct.unpack(
             "<11I", bytes(bytearray(self._usage_binary_data[0:44])))
         self.reg_runtime_crc = rt_crc
         self.reg_runtime_nvm_crc = rt_nvm_crc

--- a/axiom_tc/u48_GPIOControls.py
+++ b/axiom_tc/u48_GPIOControls.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 import struct

--- a/axiom_tc/uXX_Template.py
+++ b/axiom_tc/uXX_Template.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 TouchNetix
 # 
-# This file is part of [Project Name] and is released under the MIT License: 
+# This file is part of axiom_tc and is released under the MIT License:
 # See the LICENSE file in the root directory of this project or http://opensource.org/licenses/MIT.
 
 import struct

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,3 @@ requires-python = ">=3.8"
 [project.urls]
 Homepage = "https://www.touchnetix.com/"
 Repository = "https://github.com/TouchNetix/axiom_pylib"
-#Documentation = "https://github.com/TouchNetix/axiom_pylib/wiki"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 authors = [
     { name="Mark Satterthwaite", email="mark.satterthwaite@touchnetix.com"},
     { name="James Cameron", email="james.cameron@touchnetix.com"},
-    { name="Hannah Rossiter", email="hannah.rossiter@touchnetix.com"},
 ]
 
 classifiers = [


### PR DESCRIPTION
Move bootloader files into a class of its own.
The bootloader write chunk call has been made more efficient as there was no need to write the header and payload separately.
There were some conditions that would always assume axiom was not in bootloader mode and this led to annoying exceptions etc.